### PR TITLE
Added fixed (instead of parsed) UDP forwarding address

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,16 @@ optional arguments:
   -h, --help           show this help message and exit
   --udp-addr UDP_ADDR  Address of the UDP receiver for broadcasting messages (default=localhost)
   --udp-port UDP_PORT  Port of the UDP receiver (default=57142)
+  --fwd-fixed          Forward UDP to fixed target address/port
+  --fwd-addr FWD_ADDR  Address of the UDP target for messages (default=localhost)
+  --fwd-port FWD_PORT  Port of the UDP target (default=57143)
   --addr ADDR          WebSocket address to listen (default=0.0.0.0)
   --port PORT          WebSocket port to listen (default=8765)
+  --quiet              No verbose output
 ```
 
-The server expects binary messages following the format:
+If the `fwd-fixed` option is not given (default behavior),
+the server expects binary messages following the format:
 
 **address_length**(uint32)**address**(string)**port**(uint32)**data**
 
@@ -42,3 +47,6 @@ For example, to send the message `hello world` to `localhost:57120`, one would s
 `b'\x09\x00\x00\x00localhost\x20\xdf\x00\x00hello, world'`
 
 The first 4 bytes `b'\x09\x00\x00\x00` represents 9, then comes `b'localhost'` and lastly `b'\x20\xdf\x00\x00'` for 57120. Whatever comes after this is forwarded.
+
+
+If the `fwd-fixed` option is given, the original message data will be forwarded unaltered.

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='ws2udp',
-      version='0.1.6',
-      author='Bruno Gola',
-      author_email='me@bgo.la',
+      version='0.1.7',
+      author='Bruno Gola, additions by Thomas Grill',
+      author_email='me@bgo.la, gr@grrrr.org',
       description='A WebSocket to UDP proxy',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/ws2udp/__main__.py
+++ b/ws2udp/__main__.py
@@ -10,12 +10,15 @@ def main():
     parser = argparse.ArgumentParser(
         description="WebSocket to UDP proxy"
         )
-    parser.add_argument("--udp-addr", default="localhost", help="Address of the UDP receiver for broadcasting messages (default=localhost)")
-    parser.add_argument("--udp-port", default="57142", help="Port of the UDP receiver (default=57142)")
-    parser.add_argument("--addr", default="0.0.0.0", help="WebSocket address to listen (default=0.0.0.0)")
-    parser.add_argument("--port", default=8765, help="WebSocket port to listen (default=8765)")
+    parser.add_argument("--udp-addr", default="localhost", help="Address of the UDP receiver for broadcasting messages (default=%(default)s)")
+    parser.add_argument("--udp-port", default="57142", help="Port of the UDP receiver (default=%(default)s)")
+    parser.add_argument("--fwd-fixed", action='store_true', help="Forward UDP to fixed target address/port")
+    parser.add_argument("--fwd-addr", default="localhost", help="Address of the UDP target for messages (default=%(default)s)")
+    parser.add_argument("--fwd-port", default="57143", help="Port of the UDP target (default=%(default)s)")
+    parser.add_argument("--addr", default="0.0.0.0", help="WebSocket address to listen (default=%(default)s)")
+    parser.add_argument("--port", default=8765, help="WebSocket port to listen (default=%(default)s)")
     parser.add_argument("--quiet", action='store_true', help="No verbose output")
-    
+
     args = parser.parse_args()
 
     if args.quiet:
@@ -26,9 +29,14 @@ def main():
     udp_addr = (args.udp_addr, int(args.udp_port))
     logging.info(f"Forwarding WebSocket messages received on {args.addr}:{args.port}")
     logging.info(f"Broadcasting UDP messages received on {args.udp_addr}:{args.udp_port}")
+    if args.fwd_fixed:
+        fwd_addr = (args.fwd_addr, int(args.fwd_port))
+        logging.info(f"Forwarding UDP messages to {args.fwd_addr}:{args.fwd_port}")
+    else:
+        fwd_addr = None
 
     try:
-        asyncio.run(run(udp_addr, args.addr, args.port))
+        asyncio.run(run(udp_addr, args.addr, args.port, fwd_addr=fwd_addr))
         asyncio.get_event_loop().run_forever()
     except KeyboardInterrupt:
         logging.info("Quitting...")


### PR DESCRIPTION
This backwards-compatible PR adds the capability to define a fixed UDP forwarding address.

If the `fwd-fixed` option is given in `__main__.main`, the `fwd-addr:fwd-port` address is used instead of the usually dynamically parsed address.

The UDP message is forwarded as is, without stripping header bytes as in the normal case.
